### PR TITLE
Replace generics with pointers

### DIFF
--- a/src/array.vala
+++ b/src/array.vala
@@ -218,22 +218,90 @@ public class Array : Object
                           _strides,
                           data.slice ((int) _offset_for_index (from), (int) _offset_for_index (to)));
     }
+
+    private inline void
+    _append_from_index (StringBuilder sb, ssize_t[] index)
     {
-        return new Array<T> (scalar_size,
-                                      _shape_from_slice (from, to),
-                                      _strides,
-                                      data.slice ((int) _offset_for_index (from), (int) _offset_for_index (to)));
+        sb.append_c ('\n');
+
+        // vector style
+        if (index.length == ndim - 1) {
+            sb.append_c ('[');
+            for (var i = 0; i < shape[index.length]; i++) {
+                if (i > 0)
+                    sb.append_c (' ');
+                // index and print the scalar
+                ssize_t[] subindex = index;
+                subindex += i;
+                sb.append (get_value (subindex).strdup_contents ());
+                if (i < shape[index.length] - 1)
+                    sb.append_c ('\n');
+            }
+            sb.append_c (']');
+        }
+
+        // matrix style
+        else if (index.length == ndim - 2) {
+            sb.append_c ('[');
+            // last dim is printed vertically
+            for (var j = 0; j < shape[index.length + 1]; j++) {
+                if (j > 0) {
+                    sb.append_c (' ');
+                }
+                for (var i = 0; i < shape[index.length]; i++) {
+                    if (i > 0) {
+                        sb.append_c (' ');
+                    }
+                    sb.append_c (j == 0 ? '[' : ' ');
+
+                    // index and print the scalar
+                    ssize_t[] subindex = index;
+                    subindex += i;
+                    subindex += j;
+                    sb.append (get_value (subindex).strdup_contents ());
+
+                    if (j == shape[index.length + 1] - 1) {
+                        sb.append_c (']');
+                    } else {
+                        sb.append_c (',');
+                    }
+                }
+                if (j < shape[index.length + 1] - 1) {
+                    sb.append_c ('\n');
+                }
+            }
+            sb.append_c (']');
+        }
+
+        // embedded matrix style (humans can't see beyond!)
+        else {
+            sb.append_c ('[');
+            for (var i = 0; i < shape[index.length]; i++) {
+                ssize_t[] subindex = index;
+                subindex += i;
+                _append_from_index (sb, subindex);
+            }
+            sb.append_c (']');
+        }
     }
 
     public string
     to_string()
     {
         StringBuilder sb = new StringBuilder();
-        sb.append("<Array>");
-        sb.append("(");
-        sb.append_printf("Type=%s,", this.scalar_type.name());
-        sb.append_printf("data=%p,", _data);
-        sb.append(")");
+        sb.append_printf("dtype: %s, ", scalar_type.name ());
+        sb.append_printf("dsize: %" + size_t.FORMAT + ", ", scalar_size);
+        sb.append_printf ("shape: (");
+        for (var i = 0; i < ndim; i++) {
+            sb.append_printf ("%" + size_t.FORMAT, shape[i]);
+            if (i < ndim - 1) {
+                sb.append (", ");
+            }
+        }
+        sb.append_c (')');
+        sb.append_printf (", ");
+        sb.append_printf ("mem: %" + size_t.FORMAT + "B", data.length);
+        _append_from_index (sb, {});
         return sb.str;
     }
 

--- a/src/array.vala
+++ b/src/array.vala
@@ -219,72 +219,6 @@ public class Array : Object
                           data.slice ((int) _offset_for_index (from), (int) _offset_for_index (to)));
     }
 
-    private inline void
-    _append_from_index (StringBuilder sb, ssize_t[] index)
-    {
-        sb.append_c ('\n');
-
-        // vector style
-        if (index.length == ndim - 1) {
-            sb.append_c ('[');
-            for (var i = 0; i < shape[index.length]; i++) {
-                if (i > 0)
-                    sb.append_c (' ');
-                // index and print the scalar
-                ssize_t[] subindex = index;
-                subindex += i;
-                sb.append (get_value (subindex).strdup_contents ());
-                if (i < shape[index.length] - 1)
-                    sb.append_c ('\n');
-            }
-            sb.append_c (']');
-        }
-
-        // matrix style
-        else if (index.length == ndim - 2) {
-            sb.append_c ('[');
-            // last dim is printed vertically
-            for (var j = 0; j < shape[index.length + 1]; j++) {
-                if (j > 0) {
-                    sb.append_c (' ');
-                }
-                for (var i = 0; i < shape[index.length]; i++) {
-                    if (i > 0) {
-                        sb.append_c (' ');
-                    }
-                    sb.append_c (j == 0 ? '[' : ' ');
-
-                    // index and print the scalar
-                    ssize_t[] subindex = index;
-                    subindex += i;
-                    subindex += j;
-                    sb.append (get_value (subindex).strdup_contents ());
-
-                    if (j == shape[index.length + 1] - 1) {
-                        sb.append_c (']');
-                    } else {
-                        sb.append_c (',');
-                    }
-                }
-                if (j < shape[index.length + 1] - 1) {
-                    sb.append_c ('\n');
-                }
-            }
-            sb.append_c (']');
-        }
-
-        // embedded matrix style (humans can't see beyond!)
-        else {
-            sb.append_c ('[');
-            for (var i = 0; i < shape[index.length]; i++) {
-                ssize_t[] subindex = index;
-                subindex += i;
-                _append_from_index (sb, subindex);
-            }
-            sb.append_c (']');
-        }
-    }
-
     public string
     to_string()
     {
@@ -301,8 +235,13 @@ public class Array : Object
         sb.append_c (')');
         sb.append_printf (", ");
         sb.append_printf ("mem: %" + size_t.FORMAT + "B", data.length);
-        _append_from_index (sb, {});
-        return sb.str;
+        var @out = new MemoryOutputStream.resizable ();
+        try {
+            new StringFormatter (this).to_stream (@out);
+        } catch (Error err) {
+            error (err.message);
+        }
+        return (string) @out.steal_data ();
     }
 
 }

--- a/src/arrayiterator.vala
+++ b/src/arrayiterator.vala
@@ -1,8 +1,8 @@
 namespace Vast {
 
-    public class ArrayIterator<T>
+    public class ArrayIterator
     {
-        public Array<T> array;
+        public Array array;
 
         public ssize_t [] cursor;
         private ssize_t offset;
@@ -46,12 +46,26 @@ namespace Vast {
             return !this.ended;
         }
 
-        public unowned T get() {
-            return (T) ((uint8*) array.data.get_data () + offset);
+        public void* get()
+        {
+            return (uint8*) array.data.get_data () + offset;
         }
 
-        public void set(T val) {
-            Memory.copy((uint8*) array.data.get_data () + offset, val, sizeof(T));
+        public Value
+        get_value ()
+        {
+            return array.get_value (cursor);
+        }
+
+        public void set(void* val)
+        {
+            Memory.copy((uint8*) array.data.get_data () + offset, val, array.scalar_size);
+        }
+
+        public void
+        set_value (Value val)
+        {
+            array.set_value (cursor, val);
         }
 
         public void reset()
@@ -72,7 +86,7 @@ namespace Vast {
                 this.cursor[i] = cursor[i];
                 this.offset += this.cursor[i] * this.array.strides[i];
             }
-            this.ended = false; 
+            this.ended = false;
             for(var i = 0; i < cursor.length; i ++) {
                 if(cursor[i] >= array.shape[i]) {
                     this.ended = true;
@@ -85,7 +99,7 @@ namespace Vast {
         {
             return this.ended;
         }
-        
+
     }
 
 }

--- a/src/formatter.vala
+++ b/src/formatter.vala
@@ -1,0 +1,21 @@
+using GLib;
+
+public abstract class Vast.Formatter : Object
+{
+    /**
+     * The array this is formatting.
+     */
+    public Array array { get; construct; }
+
+    /**
+     * Format the array into the provided {@link GLib.OutputStream}.
+     */
+    public abstract bool to_stream (OutputStream @out, Cancellable? cancellable = null) throws Error;
+
+    public virtual async bool to_stream_async (OutputStream @out,
+                                               int          priority    = GLib.Priority.DEFAULT,
+                                               Cancellable? cancellable = null) throws Error
+    {
+        return to_stream (@out, cancellable);
+    }
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -2,6 +2,8 @@ vast_sources = [
     'array.vala',
     'arrayiterator.vala',
     'function.vala',
+    'formatter.vala',
+    'string-formatter.vala'
      ]
 
 vast_lib = library('vast-1.0', vast_sources,

--- a/src/string-formatter.vala
+++ b/src/string-formatter.vala
@@ -1,0 +1,79 @@
+public class Vast.StringFormatter : Vast.Formatter
+{
+    public StringFormatter (Array array)
+    {
+        Object (array: array);
+    }
+
+    private inline void
+    _append_from_index (DataOutputStream @out, ssize_t[] index, Cancellable? cancellable = null) throws Error
+    {
+        @out.put_byte ('\n', cancellable);
+
+        // vector style
+        if (index.length == array.ndim - 1) {
+            @out.put_byte ('[');
+            for (var i = 0; i < array.shape[index.length]; i++) {
+                if (i > 0)
+                    @out.put_byte (' ');
+                // index and print the scalar
+                ssize_t[] subindex = index;
+                subindex += i;
+                @out.put_string (array.get_value (subindex).strdup_contents (), cancellable);
+                if (i < array.shape[index.length] - 1)
+                    @out.put_byte ('\n', cancellable);
+            }
+            @out.put_byte (']', cancellable);
+        }
+
+        // matrix style
+        else if (index.length == array.ndim - 2) {
+            @out.put_byte ('[');
+            // last dim is printed vertically
+            for (var j = 0; j < array.shape[index.length + 1]; j++) {
+                if (j > 0) {
+                    @out.put_byte (' ', cancellable);
+                }
+                for (var i = 0; i < array.shape[index.length]; i++) {
+                    if (i > 0) {
+                        @out.put_byte (' ', cancellable);
+                    }
+                    @out.put_byte (j == 0 ? '[' : ' ');
+
+                    // index and print the scalar
+                    ssize_t[] subindex = index;
+                    subindex += i;
+                    subindex += j;
+                    @out.put_string (array.get_value (subindex).strdup_contents (), cancellable);
+
+                    if (j == array.shape[index.length + 1] - 1) {
+                        @out.put_byte (']', cancellable);
+                    } else {
+                        @out.put_byte (',', cancellable);
+                    }
+                }
+                if (j < array.shape[index.length + 1] - 1) {
+                    @out.put_byte ('\n', cancellable);
+                }
+            }
+            @out.put_byte (']', cancellable);
+        }
+
+        // embedded matrix style (humans can't see beyond!)
+        else {
+            @out.put_byte ('[');
+            for (var i = 0; i < array.shape[index.length]; i++) {
+                ssize_t[] subindex = index;
+                subindex += i;
+                _append_from_index (@out, subindex, cancellable);
+            }
+            @out.put_byte (']', cancellable);
+        }
+    }
+
+    public override bool to_stream (OutputStream @out, Cancellable? cancellable = null) throws Error
+    {
+        _append_from_index (new DataOutputStream (@out), {}, cancellable);
+        return true;
+    }
+}

--- a/tests/vast-test.vala
+++ b/tests/vast-test.vala
@@ -6,99 +6,147 @@ int main (string[] args) {
 
     Test.add_func ("/array", () => {
         message("hello");
-        var a = new Vast.Array<double?> (sizeof (double), {10});
-        message("a = %s", a.to_string());
-        var b = new Vast.Array<double?> (sizeof (double), {10}, null, a.data);
-        message("b = %s", b.to_string());
+        var a = new Vast.Array (typeof (double), sizeof (double), {10});
+        var b = new Vast.Array (typeof (double), sizeof (double), {10}, null, a.data);
+
+        assert (a.data == b.data);
 
         for(var i = 0; i < 10; i ++) {
-            a.set_scalar({i}, (double) i);
-            assert (i == a.get_scalar ({i}));
+            a.set_value ({i}, (double) i);
+            assert (i == a.get_value ({i}).get_double ());
         }
 
         for(var i = 0; i < 10; i ++) {
-            assert (i == a.get_scalar ({i}));
-            assert (i == b.get_scalar ({i}));
+            assert (i == a.get_value ({i}).get_double ());
+            assert (i == b.get_value ({i}).get_double ());
         }
 
         // negative index
         for(var i = -1; i > -10; i--) {
-            assert (10 + i == a.get_scalar ({i}));
-            assert (10 + i == b.get_scalar ({i}));
+            assert (10 + i == a.get_value ({i}).get_double ());
+            assert (10 + i == b.get_value ({i}).get_double ());
         }
 
-        var iter = a.iterator();
-        while(iter.next()) {
-            message("%g", iter.get());
-            iter.set((double) 0);
-            message("%g", iter.get());
+        foreach (var val in a) {
+            message ("%f", *(double*) val);
         }
     });
 
-    Test.add_func ("/array/large", () => {
-        assert (sizeof (Value) > sizeof (void*));
+    Test.add_func ("/array/to_string", () => {
+        var s = new Vast.Array (typeof (double), sizeof (double), {1});
+        s.set_value ({1}, 1);
+        message("s = %s", s.to_string());
 
-        var a = new Vast.Array<Value?> (sizeof (Value), {10});
+        var v = new Vast.Array (typeof (double), sizeof (double), {6});
+        v.set_value ({0}, 1);
+        v.set_value ({1}, 1);
+        v.set_value ({2}, 1);
+        v.set_value ({3}, 1);
+        v.set_value ({4}, 1);
+        v.set_value ({5}, 1);
+        message("v = %s", v.to_string());
 
-        var val = Value (typeof (string));
-        val.set_string ("test");
+        var m = new Vast.Array (typeof (double), sizeof (double), {5, 6});
+        m.set_value ({0, 1}, 1);
+        m.set_value ({0, 2}, 1);
+        m.set_value ({0, 3}, 1);
+        m.set_value ({0, 4}, 1);
+        m.set_value ({0, 5}, 1);
+        message("m = %s", m.to_string());
 
-        a.set_scalar ({0}, val);
+        var a = new Vast.Array (typeof (double), sizeof (double), {4, 5, 6});
+        a.set_value ({0, 0, 1}, 1);
+        a.set_value ({0, 0, 2}, 1);
+        a.set_value ({0, 0, 3}, 1);
+        a.set_value ({0, 0, 4}, 1);
+        a.set_value ({0, 0, 5}, 1);
+        message("a = %s", a.to_string());
 
-        assert (val != a.get_scalar ({0}));
-        assert ("test" == a.get_scalar ({0}).get_string ());
+        var b = new Vast.Array (typeof (double), sizeof (double), {1, 2, 3, 4, 5, 6});
+        assert (6 == b.ndim);
+        b.set_value ({0, 0, 0, 0, 0, 1}, 1);
+        b.set_value ({0, 0, 0, 0, 0, 2}, 1);
+        b.set_value ({0, 0, 0, 0, 0, 3}, 1);
+        b.set_value ({0, 0, 0, 0, 0, 4}, 1);
+        b.set_value ({0, 0, 0, 0, 0, 5}, 1);
+        message("b = %s", b.to_string());
+
+        var c = new Vast.Array (typeof (double), sizeof (double), {});
+        message ("c = %s", c.to_string ());
+    });
+
+    Test.add_func ("/array/reshape", () => {
+        // var a = new Vast.Array<char?> (sizeof (char), {10});
+        // a.reshape ({5, 2});
+        // assert (5 == a.shape[0]);
+        // assert (2 == a.shape[1]);
     });
 
     Test.add_func ("/array/compact", () => {
-        var a = new Vast.Array<uint8?> (sizeof (uint8), {200});
+        var a = new Vast.Array (typeof (uint8), sizeof (uint8), {200});
 
         assert (sizeof (uint8) * 200 == a.size);
 
-        a.set_scalar ({0}, 10);
-        assert (10 == a.get_scalar ({0}));
+        a.set_value ({0}, 10);
+        assert (10 == a.get_value ({0}).get_uchar ());
+    });
+
+    Test.add_func ("/array/string", () => {
+        var a = new Vast.Array (typeof (string), sizeof (string), {10});
+
+        a.set_value ({0}, "test");
+
+        message (a.to_string ());
+
+        assert ("test" == a.get_value ({0}).get_string ());
+        assert (4 == a.get_value ({0}).get_string ().data.length);
+    });
+
+    Test.add_func ("/array/large", () => {
+        var a = new Vast.Array (typeof (char), sizeof (char), {100, 100, 100, 100});
     });
 
     Test.add_func ("/array/negative_indexing", () => {
-        var a = new Vast.Array<double?> (sizeof (double), {10, 20});
+        var a = new Vast.Array (typeof (double), sizeof (double), {10, 20});
 
         for(var i = 0; i < 10; i ++) {
             for (var j = 0; j < 20; j++) {
-                a.set_scalar({i, j}, (double) i * j);
+                a.set_value ({i, j}, (double) i * j);
             }
         }
 
         // negative index
         for(var i = -1; i > -10; i--) {
-            assert (10 + i == a.get_scalar ({i, 1}));
+            assert (10 + i == a.get_value ({i, 1}).get_double ());
         }
 
         for(var j = -1; j > -20; j--) {
-            assert (20 + j == a.get_scalar ({1, j}));
+            assert (20 + j == a.get_value ({1, j}).get_double ());
         }
 
         // diagonal negative indexing
         for (var i = -1, j = -1; i > -10 && j > -10; i-- + j--) {
-            assert ((10 + i) * (20 + j) == a.get_scalar ({i, j}));
+            assert ((10 + i) * (20 + j) == a.get_value ({i, j}).get_double ());
         }
     });
 
     Test.add_func ("/array/slice", () => {
-        var a = new Vast.Array<int64?> (sizeof (int64), {30, 30});
+        var a = new Vast.Array (typeof (int64), sizeof (int64), {30, 30});
 
         for (var i = 0; i < 30; i++) {
             for (var j = 0; j < 30; j++) {
-                a.set_scalar ({i, j}, i * j);
+                a.set_value ({i, j}, i * j);
             }
         }
 
         var b = a.slice ({10, 10}, {20, 20});
-        assert (100 == b.get_scalar ({0, 0}));
+        assert (100 == b.get_value ({0, 0}).get_int64 ());
         assert (10 == b.shape[0]);
         assert (10 == b.shape[1]);
 
         // negative indexing
         var c = a.slice ({-10, -10}, {-1, -1});
-        assert (400 == c.get_scalar ({0, 0}));
+        assert (400 == c.get_value ({0, 0}).get_int64 ());
         assert (9 == c.shape[0]);
         assert (9 == c.shape[1]);
     });
@@ -113,14 +161,14 @@ int main (string[] args) {
             assert_not_reached ();
         }
 
-        var a = new Vast.Array<char?> (sizeof (char),
+        var a = new Vast.Array (typeof (char), sizeof (char),
                                       {1},
                                       null,
                                       mapped_file.get_bytes ());
 
-        assert ('a' == a.get_scalar ({0}));
+        assert ('a' == a.get_value ({0}));
 
-        a.set_scalar ({0}, 'b');
+        a.set_value ({0}, 'b');
 
         assert ('b' == mapped_file.get_contents ()[0]);
     });


### PR DESCRIPTION
There's some work to do to fully implement pointer to `GValue` and its reciprocate. This endpoint is just a convenience because it's generally more efficient to work directly with pointers.

I also provide a pretty-print implementation based on `GLib.Value.strdup_contents`. It's nice as it considers matrix and vertices and print them vertically.