### PR TITLE
Use a single construct block

### DIFF
--- a/src/array.vala
+++ b/src/array.vala
@@ -3,7 +3,7 @@ using GLib;
 public class Vast.Array : Object
 {
     /* GType of the scalar elements, immutable */
-    public Type scalar_type { get; construct; }
+    public Type scalar_type { get; construct; /* implicitly typeof (void) */ }
 
     /* size of a scalar element in bytes, immutable */
     public size_t scalar_size { get; construct; default = sizeof (void); }
@@ -39,7 +39,8 @@ public class Vast.Array : Object
     public size_t size {get; private set;}
 
     /* GObject that owns the memory buffer for storage of scalar elements */
-    public Bytes? data {get; construct; }
+    /* if 'null', it will be allocated internally */
+    public Bytes? data {get; construct; default = null;}
 
     /* pointer to the memory location of 0th element */
     private uint8* _baseptr;

--- a/src/array.vala
+++ b/src/array.vala
@@ -50,6 +50,7 @@ public class Vast.Array : Object
 
     construct {
         /* initializes the read-only attributes of the Array Object */
+        assert (_dimension <= 32);
 
         /* We will copy the in-values from g_object_new */
         for (var i = 0; i < _dimension; i ++) {
@@ -98,6 +99,7 @@ public class Vast.Array : Object
                   ssize_t[] strides = {},
                   Bytes?    data    = null,
                   size_t    origin  = 0)
+        requires (shape.length <= 32)
         requires (scalar_size > 0)
         requires (_size_from_shape (shape) > 0)
     {

--- a/src/array.vala
+++ b/src/array.vala
@@ -81,6 +81,7 @@ public class Vast.Array : Object
             _size *= _shape[i];
         }
 
+        /* provide a default bytes object for the buffer */
         _data = _data ?? new Bytes (new uint8[scalar_size * _size]);
 
         assert (_origin < _data.length);

--- a/src/array.vala
+++ b/src/array.vala
@@ -42,10 +42,10 @@ public class Vast.Array : Object
     /* if 'null', it will be allocated internally */
     public Bytes? data {get; construct; default = null;}
 
-    /* pointer to the memory location of 0th element */
+    /* pointer to the memory location of buffer */
     private uint8* _baseptr;
 
-    /* offset to the memory location of 0th element */
+    /* offset to the memory location of 0th element in bytes relative to _baseptr */
     public size_t origin {get; construct; default = 0;}
 
 

--- a/src/array.vala
+++ b/src/array.vala
@@ -53,9 +53,7 @@ public class Vast.Array : Object
         assert (_dimension <= 32);
 
         /* We will copy the in-values from g_object_new */
-        for (var i = 0; i < _dimension; i ++) {
-            _shape[i] = _shape_in[i];
-        }
+        Memory.copy (_shape, _shape_in, _dimension * sizeof (size_t));
 
         if (_strides_in == null) {
             /* assume C contiguous strides */

--- a/src/array.vala
+++ b/src/array.vala
@@ -53,8 +53,14 @@ public class Vast.Array : Object
         /* initializes the read-only attributes of the Array Object */
         assert (_dimension <= 32);
 
-        /* We will copy the in-values from g_object_new */
-        Memory.copy (_shape, _shape_in, _dimension * sizeof (size_t));
+        if (_shape_in == null) {
+            assert (_dimension == 0);
+        } else {
+            /* We will copy the in-values from g_object_new */
+            Memory.copy (_shape, _shape_in, _dimension * sizeof (size_t));
+            /* the input pointers from gobject is no longer useful, void them.*/
+            _shape_in = null;
+        }
 
         if (_strides_in == null) {
             /* assume C contiguous strides */
@@ -65,6 +71,8 @@ public class Vast.Array : Object
             for (var i = 0; i < _dimension; i ++) {
                 _strides[i] = _strides_in[i];
             }
+            /* the input pointers from gobject is no longer useful, void them.*/
+            _strides_in = null;
         }
 
         /* calculate size, since it is immutable, we do it once here */
@@ -78,10 +86,6 @@ public class Vast.Array : Object
         assert (_origin < _data.length);
 
         _baseptr = (uint8*) _data.get_data () + _origin;
-
-        /* the input pointers from gobject is no longer useful, void them.*/
-        _shape_in = null;
-        _strides_in = null;
     }
 
     private static inline size_t

--- a/src/array.vala
+++ b/src/array.vala
@@ -172,7 +172,7 @@ public class Vast.Array : Object
 
     public Array
     reshape (size_t[] new_shape)
-        requires (_data == null || _size_from_shape (_shape[0:dimension]) == _size_from_shape (new_shape))
+        requires (_size_from_shape (_shape[0:dimension]) == _size_from_shape (new_shape))
     {
         return new Array (scalar_type,
                           scalar_size,

--- a/src/iterator.vala
+++ b/src/iterator.vala
@@ -19,10 +19,10 @@ public class Vast.Iterator : Object
         get { return _offset; }
     }
 
-    public uint8 * origin {get; private set;}
+    private uint8* _baseptr;
 
     construct {
-        origin = array.origin;
+        _baseptr = (uint8*) array.data.get_data () - array.origin;
     }
 
     public Iterator (Array array)
@@ -63,26 +63,26 @@ public class Vast.Iterator : Object
     get ()
         requires (_cursor != null)
     {
-        return _origin + _offset;
+        return _baseptr + _offset;
     }
 
     public Value
     get_value ()
     {
-        return array._memory_to_value (_origin + _offset);
+        return array._memory_to_value (_baseptr + _offset);
     }
 
     public void
     set (void* val)
         requires (_cursor != null)
     {
-        Memory.copy (_origin + _offset, val, array.scalar_size);
+        Memory.copy (_baseptr + _offset, val, array.scalar_size);
     }
 
     public void
     set_value (Value val)
     {
-        array._value_to_memory (val, _origin + _offset);
+        array._value_to_memory (val, _baseptr + _offset);
     }
 
     public void

--- a/src/iterator.vala
+++ b/src/iterator.vala
@@ -19,6 +19,12 @@ public class Vast.Iterator : Object
         get { return _offset; }
     }
 
+    public uint8 * origin {get; private set;}
+
+    construct {
+        origin = array.origin;
+    }
+
     public Iterator (Array array)
     {
         base (array: array);
@@ -57,26 +63,26 @@ public class Vast.Iterator : Object
     get ()
         requires (_cursor != null)
     {
-        return array._cached_data + _offset;
+        return _origin + _offset;
     }
 
     public Value
     get_value ()
     {
-        return array._memory_to_value (array._cached_data + _offset);
+        return array._memory_to_value (_origin + _offset);
     }
 
     public void
     set (void* val)
         requires (_cursor != null)
     {
-        Memory.copy (array._cached_data + _offset, val, array.scalar_size);
+        Memory.copy (_origin + _offset, val, array.scalar_size);
     }
 
     public void
     set_value (Value val)
     {
-        array._value_to_memory (val, array._cached_data + _offset);
+        array._value_to_memory (val, _origin + _offset);
     }
 
     public void

--- a/tests/gi-test.py
+++ b/tests/gi-test.py
@@ -6,13 +6,4 @@ a = Vast.Array(scalar_type=float, scalar_size=8)
 
 assert(0 == a.get_dimension())
 assert(0 == a.get_origin())
-assert(a.get_data() is None)
-
-b = a.reshape([2, 2, 2])
-
-assert(3 == b.get_dimension())
-assert(b.get_data() is not None)
-assert(64 == b.get_data().get_size())
-
-b.set_value([0, 0, 0], 1)
-assert (1 == b.get_value([0, 0, 0]))
+assert(a.get_data() is not None)

--- a/tests/vast-test.vala
+++ b/tests/vast-test.vala
@@ -40,8 +40,6 @@ int main (string[] args) {
     Test.add_func ("/array/scalar_like", () => {
         var a = new Vast.Array (typeof (double), sizeof (double), {});
 
-        assert (null == a.shape);
-        assert (null == a.strides);
         assert (1 == a.size);
         assert (null != a.data);
         assert (sizeof (double) == a.data.get_size ());
@@ -60,14 +58,13 @@ int main (string[] args) {
         assert (0 == a.dimension);
         assert (typeof (void) == a.scalar_type);
         assert (sizeof (void) == a.scalar_size);
-        assert (null == a.shape);
-        assert (null == a.strides);
         assert (1 == a.size);
         assert (0 == a.origin);
-        assert (null == a.data);
-        assert ("dtype: void, dsize: %lu, dimension: 0, shape: (), strides: (), mem: 0B".printf (sizeof (void)) == a.to_string ());
+        assert (null != a.data);
+        //assert ("dtype: void, dsize: %lu, dimension: 0, shape: (), strides: (), mem: 0B".printf (sizeof (void)) == a.to_string ());
 
-        var b = a.reshape ({2, 2, 2, 4});
+        size_t [] shape = {2, 2, 2, 4};
+        var b = Object.new (typeof (Vast.Array), "dimension", shape.length, "shape", shape) as Vast.Array;
         assert (typeof (void) == b.scalar_type);
         assert (sizeof (void) == b.scalar_size);
         assert (2 == b.shape[0]);

--- a/tests/vast-test.vala
+++ b/tests/vast-test.vala
@@ -59,7 +59,7 @@ int main (string[] args) {
         assert (typeof (void) == a.scalar_type);
         assert (sizeof (void) == a.scalar_size);
         assert (1 == a.size);
-        assert (null != a.origin);
+        assert (0 == a.origin);
         assert (null != a.data);
         //assert ("dtype: void, dsize: %lu, dimension: 0, shape: (), strides: (), mem: 0B".printf (sizeof (void)) == a.to_string ());
 
@@ -75,7 +75,7 @@ int main (string[] args) {
         assert (2 * 4 * sizeof (void) == b.strides[1]);
         assert (4 * sizeof (void) == b.strides[2]);
         assert (sizeof (void) == b.strides[3]);
-        assert (null != b.origin);
+        assert (0 == b.origin);
         assert (null != b.data);
     });
 

--- a/tests/vast-test.vala
+++ b/tests/vast-test.vala
@@ -59,7 +59,7 @@ int main (string[] args) {
         assert (typeof (void) == a.scalar_type);
         assert (sizeof (void) == a.scalar_size);
         assert (1 == a.size);
-        assert (0 == a.origin);
+        assert (null != a.origin);
         assert (null != a.data);
         //assert ("dtype: void, dsize: %lu, dimension: 0, shape: (), strides: (), mem: 0B".printf (sizeof (void)) == a.to_string ());
 
@@ -75,7 +75,7 @@ int main (string[] args) {
         assert (2 * 4 * sizeof (void) == b.strides[1]);
         assert (4 * sizeof (void) == b.strides[2]);
         assert (sizeof (void) == b.strides[3]);
-        assert (0 == b.origin);
+        assert (null != b.origin);
         assert (null != b.data);
     });
 

--- a/tests/vast-test.vala
+++ b/tests/vast-test.vala
@@ -61,7 +61,7 @@ int main (string[] args) {
         assert (1 == a.size);
         assert (0 == a.origin);
         assert (null != a.data);
-        //assert ("dtype: void, dsize: %lu, dimension: 0, shape: (), strides: (), mem: 0B".printf (sizeof (void)) == a.to_string ());
+        assert ("dtype: void, dsize: %lu, dimension: 0, shape: (), strides: (), mem: 1B".printf (sizeof (void)) == a.to_string ());
 
         size_t [] shape = {2, 2, 2, 4};
         var b = Object.new (typeof (Vast.Array), "dimension", shape.length, "shape", shape) as Vast.Array;


### PR DESCRIPTION
In a construct block we know the construct setter of attributes have all been called. Thus we initialize the immutable property values.