### PR TITLE
array: Fix setting of boxed types

### DIFF
--- a/src/array.vala
+++ b/src/array.vala
@@ -425,13 +425,17 @@ public class Vast.Array : Object
     }
 
     internal inline Value
-    _memory_to_value (void * memory)
+    _memory_to_value (void* memory)
     {
         var val = Value (scalar_type);
 
         if (val.fits_pointer ()) {
             if (scalar_type == typeof (string)) {
                 val.set_string ((string) memory);
+            } else if (scalar_type.is_a (Type.BOXED)) {
+                var tmp_val = Value (scalar_type);
+                tmp_val.set_boxed (memory);
+                tmp_val.copy (ref val);
             } else {
                 Memory.copy (val.peek_pointer (), memory, scalar_size);
             }

--- a/tests/vast-test.vala
+++ b/tests/vast-test.vala
@@ -198,6 +198,19 @@ int main (string[] args) {
         var a = new Vast.Array (typeof (char), sizeof (char), {100, 100, 100, 100});
     });
 
+    Test.add_func ("/array/boxed_type", () => {
+        var a = new Vast.Array (typeof (DateTime), 128 /* wild guess... */, {10});
+        var b = new DateTime.now_utc ();
+        a.set_from_value ({0}, b);
+
+        unowned DateTime c = (DateTime) a.get_pointer ({0});
+        assert (b.to_string () == c.to_string ());
+
+        var d = a.get_value ({0});
+        var e = (DateTime) d.get_boxed ();
+        assert (b.to_string () == e.to_string ());
+    });
+
     Test.add_func ("/array/negative_indexing", () => {
         var a = new Vast.Array (typeof (double), sizeof (double), {10, 20});
 


### PR DESCRIPTION
This is just a failing test case so far. I'm not exactly sure of what is happening, but it seems to be a double-free.