### PR TITLE
Provide basic APIs for manipulating dense array in OpenCL kernels

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,10 @@ gio = dependency('gio-2.0', version: '>=2.32')
 math = meson.get_compiler('c').find_library('m')
 posix = meson.get_compiler('vala').find_library('posix')
 
+gocl = dependency('gocl-0.3', fallback: ['gocl', 'gocl_dep'], required: false)
+
 g_ir_compiler = find_program('g-ir-compiler', required: false)
 
 subdir('src')
+subdir('src/cl')
 subdir('tests')

--- a/src/cl/kernels/meson.build
+++ b/src/cl/kernels/meson.build
@@ -1,0 +1,3 @@
+vast_cl_kernels = [
+    'sin.cl']
+install_data(vast_cl_kernels, install_dir: 'share/vast-1.0/cl/kernels')

--- a/src/cl/kernels/sin.cl
+++ b/src/cl/kernels/sin.cl
@@ -1,0 +1,14 @@
+#include <cl/vast.h>
+
+__kernel void
+vast_sin (VastTensor       x,
+          __global double *x_data,
+          VastTensor       z,
+          __global double *z_data)
+{
+    size_t x_offset;
+    size_t z_offset;
+    vast_tensor_foreach (x, x_offset, z, z_offset)
+        *(x + x_offset) = sin (*(z + z_offset));
+    }
+}

--- a/src/cl/meson.build
+++ b/src/cl/meson.build
@@ -1,0 +1,2 @@
+install_headers(['vast.h', 'vast-array.h'], subdir: 'vast-1.0/cl')
+subdir('kernels')

--- a/src/cl/vast-tensor.h
+++ b/src/cl/vast-tensor.h
@@ -1,0 +1,51 @@
+#ifndef __VAST_CL_TENSOR_H__
+#define __VAST_CL_TENSOR_H__
+
+typedef struct _VastTensor VastTensor;
+
+struct __attribute__ ((packed)) _VastTensor
+{
+    // size_t is platform-dependant, so instead we use 64 bit fields.
+    unsigned long scalar_type;
+    unsigned long scalar_size;
+    unsigned long dimension;
+    unsigned long shape[32];
+    long          strides[32];
+    unsigned long origin;
+};
+
+/**
+ * vast_tensor_get_offset_for_index:
+ * @self: The #VastTensor
+ * @index: an index which size is given by #
+ *
+ * Returns:
+ */
+inline size_t
+vast_tensor_get_offset_for_index (VastTensor *self, unsigned int *index)
+{
+    size_t offset;
+    int i;
+
+    offset = self->origin;
+
+    for (i = 0; i < self->dimension; i++) {
+        offset += index[i] * self->strides[i];
+    }
+
+    return offset;
+}
+
+/**
+ * vast_tensor_foreach:
+ * @arr: The #VastTensor being iterated
+ * @arr_offset: Offset in bytes to retreive the corresponding element in the
+ * from the actual tensor pointer
+ *
+ * Iterate in row-major order the given tensor or tensors if varidic arguments
+ * are being used. If more arguments are being used, they alternate among
+ * #VastTensor and #size_t types.
+ */
+#define vast_tensor_foreach(arr,arr_offset,...)
+
+#endif /* __VAST_CL_TENSOR_H__ */

--- a/src/cl/vast.h
+++ b/src/cl/vast.h
@@ -1,0 +1,6 @@
+#ifndef __VAST_H__
+#define __VAST_H__
+
+#include <cl/vast-tensor.h>
+
+#endif /* __VAST_H__ */

--- a/src/meson.build
+++ b/src/meson.build
@@ -8,6 +8,10 @@ vast_sources = [
     'string-formatter.vala'
      ]
 
+if gocl.found()
+    vast_sources += 'vast-cl-tensor.c'
+endif
+
 subdir('routines')
 
 vast_lib = library('vast-1.0', vast_sources + routines_sources,

--- a/src/vast-cl-tensor.c
+++ b/src/vast-cl-tensor.c
@@ -1,0 +1,51 @@
+#include "vast-cl-tensor.h"
+
+G_DEFINE_BOXED_TYPE (VastClTensor, vast_cl_tensor, vast_cl_tensor_copy, vast_cl_tensor_free)
+
+/**
+ * vast_cl_tensor_init_from_tensor:
+ * @self: The #VastClTensor
+ * @arr: The #VastTensor
+ *
+ * Pack the meta-data of a #VastTensor into a struct suitable for OpenCL. The
+ * actual data has to be passed separately, preferably via a mapped buffer.
+ */
+void
+vast_cl_tensor_init_from_tensor (VastClTensor *self, VastTensor *arr)
+{
+    gint i;
+
+    g_return_if_fail (self != NULL);
+    g_return_if_fail (VAST_IS_TENSOR (arr));
+
+    // TODO: check for endianess of device against native
+
+    self->scalar_size = vast_tensor_get_scalar_size (arr);
+    self->dimension   = vast_tensor_get_dimension (arr);
+
+    for (i = 0; i < 32; i++) {
+        self->shape[i]   = vast_tensor_get_shape (arr)[i];
+        self->strides[i] = vast_tensor_get_strides (arr)[i];
+    }
+
+    self->origin = vast_tensor_get_origin (arr);
+}
+
+VastClTensor *
+vast_cl_tensor_copy (const VastClTensor *self)
+{
+    VastClTensor *ret;
+
+    g_return_val_if_fail (self != NULL, NULL);
+
+    ret = g_malloc (sizeof (VastClTensor));
+    memcpy (ret, self, sizeof (VastClTensor));
+
+    return ret;
+}
+
+void
+vast_cl_tensor_free (VastClTensor *self)
+{
+    g_free (self);
+}

--- a/src/vast-cl-tensor.h
+++ b/src/vast-cl-tensor.h
@@ -1,0 +1,29 @@
+#ifndef __VAST_CL_TENSOR_H__
+#define __VAST_CL_TENSOR_H__
+
+#include <vast.h>
+
+#include <CL/cl.h>
+
+G_BEGIN_DECLS
+
+typedef struct _VastClTensor VastClTensor;
+
+struct __attribute__ ((packed)) _VastClTensor
+{
+    cl_ulong scalar_type;
+    cl_ulong scalar_size;
+    cl_ulong dimension;
+    cl_ulong shape[32];
+    cl_long  strides[32];
+    cl_ulong origin;
+};
+
+void           vast_cl_tensor_init_from_tensor (VastClTensor       *self,
+                                                VastTensor         *arr);
+VastClTensor * vast_cl_tensor_copy             (const VastClTensor *self);
+void           vast_cl_tensor_free             (VastClTensor       *self);
+
+G_END_DECLS
+
+#endif /* __VAST_CL_TENSOR_H__ */

--- a/tests/gocl-test.vala
+++ b/tests/gocl-test.vala
@@ -1,0 +1,98 @@
+using Gocl;
+
+public extern struct Vast.ClTensor
+{
+    public ClTensor.from_tensor (Vast.Tensor arr);
+    uint scalar_size;
+    uint dimension;
+    uint shape[32];
+    int strides[32];
+    uint origin;
+}
+
+public int main (string[] args)
+{
+    Test.init (ref args);
+
+    Test.add_func ("/gocl", () => {
+        var context = Context.get_default_cpu_sync ();
+        var device  = context.get_device_by_index (0);
+
+        string kernel_contents;
+        try {
+            FileUtils.get_contents (Test.build_filename (Test.FileType.DIST, "..", "src", "cl", "kernels", "sin.cl"),
+                                    out kernel_contents);
+        } catch (Error err) {
+            assert_not_reached ();
+        }
+
+        var program = new Program (context, {kernel_contents});
+
+        assert (program.build_sync ("-I%s".printf (Test.build_filename (Test.FileType.DIST, "..", "src"))));
+        assert (Gocl.ProgramBuildStatus.SUCCESS == program.get_build_status (device));
+
+        var kernel = program.get_kernel ("vast_sin");
+        assert (kernel != null);
+        assert (kernel is Gocl.Kernel);
+
+        // allocate on the GPU
+        var x_buf = new Buffer (context, BufferFlags.READ_WRITE, 10 * 10 * sizeof (double), 0);
+
+        // map into virtual memory
+        var mapped_buf = x_buf.map_as_bytes_sync (device.get_default_queue (),
+                                                  BufferMapFlags.READ | BufferMapFlags.WRITE,
+                                                  0,
+                                                  (size_t) x_buf.size,
+                                                  null);
+        assert (null != mapped_buf);
+
+        var x = new Vast.Tensor (typeof (double),
+                                sizeof (double),
+                                {10, 10},
+                                {},
+                                0,
+                                mapped_buf);
+
+        x.fill_from_value (Math.PI / 2);
+
+        for (var i = 0; i < 10 * 10; i++) {
+            assert (Math.PI / 2 == ((double[])mapped_buf.get_data ())[i]);
+        }
+
+        var z_buf = new Buffer (context, BufferFlags.READ_WRITE, 10 * 10 * sizeof (double), 0);
+
+        var z = new Vast.Tensor (typeof (double),
+                                sizeof (double),
+                                {10, 10},
+                                {},
+                                0,
+                                z_buf.map_as_bytes_sync (device.get_default_queue (), BufferMapFlags.READ, 0, 10 * 10 * sizeof (double), null));
+
+        var x_cl_arr = Vast.ClTensor.from_tensor (x);
+        var z_cl_arr = Vast.ClTensor.from_tensor (z);
+
+        assert (sizeof (double) == x_cl_arr.scalar_size);
+        assert (2 == x_cl_arr.dimension);
+        assert (10 == x_cl_arr.shape[0]);
+        assert (10 == x_cl_arr.shape[1]);
+        assert (10 == x_cl_arr.strides[0]);
+        assert (1 == x_cl_arr.strides[1]);
+        assert (0 == x_cl_arr.origin);
+
+        kernel.set_argument (0, sizeof (Vast.ClTensor), &x_cl_arr);
+        kernel.set_argument_buffer (1, x_buf);
+
+        kernel.set_argument (2, sizeof (Vast.ClTensor), &z_cl_arr);
+        kernel.set_argument_buffer (3, z_buf);
+
+        assert (kernel.run_in_device_sync (device, null));
+
+        foreach (var ptr in z) {
+            assert (1.0 == *(double*) ptr);
+        }
+
+        assert (x_buf.unmap_bytes (device.get_default_queue (), mapped_buf, null));
+    });
+
+    return Test.run ();
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -4,6 +4,12 @@ test('test', executable('vast-test', 'vast-test.vala',
                           dependencies: [glib, gobject, gobject_introspection, gio, vast]),
      env: ['GI_TYPELIB_PATH=' + meson.current_build_dir() + '/../src'])
 
+if gocl.found()
+    test('gocl', executable('gocl-test', 'gocl-test.vala',
+                            dependencies: [glib, gobject, gobject_introspection, gio, vast, gocl]),
+         env: ['G_TEST_SRCDIR=' + meson.current_source_dir()])
+endif
+
 if g_ir_compiler.found()
     test('gi', find_program('gi-test.py'),
          env: ['GI_TYPELIB_PATH=' + meson.current_build_dir() + '/../src',


### PR DESCRIPTION
Stuff to do:

 - [ ] fully working test case
 - [ ] minimal API for manipulating dense arrays from OpenCL C
 - [ ] integration with `Vast.Network.Operation` to call an OpenCL kernel and build graph with it
 - [ ] maybe a `GoclGraphExecutor` that would allocate buffers and evaluate the graph by chaining kernels on the GPU