### PR TITLE
Rename 'Array' for 'Tensor'

### DIFF
--- a/src/formatter.vala
+++ b/src/formatter.vala
@@ -3,12 +3,12 @@ using GLib;
 public abstract class Vast.Formatter : Object
 {
     /**
-     * The array this is formatting.
+     * The tensor this is formatting.
      */
-    public Array array { get; construct; }
+    public Tensor tensor { get; construct; }
 
     /**
-     * Format the array into the provided {@link GLib.OutputStream}.
+     * Format the tensor into the provided {@link GLib.OutputStream}.
      */
     public abstract bool to_stream (OutputStream @out, Cancellable? cancellable = null) throws Error;
 

--- a/src/function.vala
+++ b/src/function.vala
@@ -8,12 +8,12 @@ public class Vast.Function : Object
     }
 
     public void
-    invokev (Array[] arrays)
-        requires (arrays.length >= 2)
+    invokev (Tensor[] tensors)
+        requires (tensors.length >= 2)
     {
-        var in_args = new GI.Argument[arrays.length];
-        for (var i = 0; i < arrays.length; i++) {
-            in_args[i] = GI.Argument () { v_pointer = arrays[i] };
+        var in_args = new GI.Argument[tensors.length];
+        for (var i = 0; i < tensors.length; i++) {
+            in_args[i] = GI.Argument () { v_pointer = tensors[i] };
         }
         try {
             _function_info.invoke (in_args,
@@ -27,15 +27,15 @@ public class Vast.Function : Object
     public void
     invoke_valist (va_list list)
     {
-        var args = new Array[function_info.get_n_args ()];
+        var args = new Tensor[function_info.get_n_args ()];
         for (;;) {
             unowned string name = list.arg<string?> ();
-            unowned Array  arr  = list.arg<Array?>  ();
+            unowned Tensor  arr  = list.arg<Tensor?>  ();
             if (name == null) {
                 break;
             }
             if (arr == null) {
-                error ("Expected an array after named argument '%s'.", name);
+                error ("Expected an tensor after named argument '%s'.", name);
             }
             for (var i = function_info.get_n_args (); i > 0; i--) {
                 var arg_info = function_info.get_arg (i - 1);

--- a/src/gi/overrides/Vast.py
+++ b/src/gi/overrides/Vast.py
@@ -2,5 +2,5 @@ from ..module import get_introspection_module
 
 Vast = get_introspection_module('Vast')
 
-Vast.Array.__getitem__ = lambda self, i: self.get_value(i)
-Vast.Array.__setitem__ = lambda self, i, item: self.set_value(i, item)
+Vast.Tensor.__getitem__ = lambda self, i: self.get_value(i)
+Vast.Tensor.__setitem__ = lambda self, i, item: self.set_value(i, item)

--- a/src/iterator.vala
+++ b/src/iterator.vala
@@ -2,7 +2,7 @@ using GLib;
 
 public class Vast.Iterator : Object
 {
-    public Array array { get; construct; }
+    public Tensor tensor { get; construct; }
 
     [CCode (array_length = false)]
     private ssize_t[] _cursor = null;
@@ -22,12 +22,12 @@ public class Vast.Iterator : Object
     private uint8* _baseptr;
 
     construct {
-        _baseptr = (uint8*) array.data.get_data () - array.origin * array.scalar_size;
+        _baseptr = (uint8*) tensor.data.get_data () - tensor.origin * tensor.scalar_size;
     }
 
-    public Iterator (Array array)
+    public Iterator (Tensor tensor)
     {
-        base (array: array);
+        base (tensor: tensor);
     }
 
     public bool
@@ -35,23 +35,23 @@ public class Vast.Iterator : Object
     {
         if (_cursor == null) {
             /*
-             * For scalar-like array, we cannot use an empty '_cursor' as it
+             * For scalar-like tensor, we cannot use an empty '_cursor' as it
              * would be interpreted as 'null', thus we create a phony one.
              */
-            _cursor = new ssize_t[array.dimension.clamp (1, size_t.MAX)];
-            Memory.set (_cursor, 0, array.dimension.clamp (1, size_t.MAX) * sizeof (ssize_t));
+            _cursor = new ssize_t[tensor.dimension.clamp (1, size_t.MAX)];
+            Memory.set (_cursor, 0, tensor.dimension.clamp (1, size_t.MAX) * sizeof (ssize_t));
             _offset = 0;
             return true;
         }
 
-        for (var i = array.dimension; i > 0; i--) {
+        for (var i = tensor.dimension; i > 0; i--) {
             _cursor[i - 1] = _cursor[i - 1] + 1;
-            _offset        = _offset + array.strides[i - 1] * array.scalar_size;
-            if (_cursor[i - 1] < array.shape[i - 1]) {
+            _offset        = _offset + tensor.strides[i - 1] * tensor.scalar_size;
+            if (_cursor[i - 1] < tensor.shape[i - 1]) {
                 return true;
             } else {
-                _cursor[i - 1] -= (ssize_t) array.shape[i - 1];
-                _offset        -= array.shape[i - 1] * array.strides[i - 1] * array.scalar_size;
+                _cursor[i - 1] -= (ssize_t) tensor.shape[i - 1];
+                _offset        -= tensor.shape[i - 1] * tensor.strides[i - 1] * tensor.scalar_size;
             }
         }
 
@@ -77,7 +77,7 @@ public class Vast.Iterator : Object
     get_value ()
         requires (_cursor != null)
     {
-        return array._memory_to_value (_baseptr + _offset);
+        return tensor._memory_to_value (_baseptr + _offset);
     }
 
     public Value
@@ -87,7 +87,7 @@ public class Vast.Iterator : Object
         if (get_value ().transform (ref dest_value)) {
             return dest_value;
         } else {
-            error ("Could not transform '%s' into '%s'.", array.scalar_type.name (),
+            error ("Could not transform '%s' into '%s'.", tensor.scalar_type.name (),
                                                           dest_type.name ());
         }
     }
@@ -96,7 +96,7 @@ public class Vast.Iterator : Object
     set_from_pointer (void* val)
         requires (_cursor != null)
     {
-        Memory.copy (_baseptr + _offset, val, array.scalar_size);
+        Memory.copy (_baseptr + _offset, val, tensor.scalar_size);
     }
 
     public void
@@ -104,7 +104,7 @@ public class Vast.Iterator : Object
         requires (_cursor != null)
     {
         var val_copy = val;
-        array._value_to_memory (ref val_copy, _baseptr + _offset);
+        tensor._value_to_memory (ref val_copy, _baseptr + _offset);
     }
 
     public void
@@ -117,12 +117,12 @@ public class Vast.Iterator : Object
     move ([CCode (array_length = false)] ssize_t[] destination)
     {
         if (_cursor == null) {
-            _cursor = new ssize_t[array.dimension];
+            _cursor = new ssize_t[tensor.dimension];
         }
         _offset = 0;
-        for (var i = 0; i < array.dimension; i++) {
+        for (var i = 0; i < tensor.dimension; i++) {
             _cursor[i] = destination[i];
-            _offset   += destination[i] * array.strides[i] * array.scalar_size;
+            _offset   += destination[i] * tensor.strides[i] * tensor.scalar_size;
         }
     }
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,6 @@
 vast_sources = [
-    'array.vala',
-    'array.c',
+    'tensor.vala',
+    'tensor.c',
     'iterator.vala',
     'function.vala',
     'gradient.vala',

--- a/src/routines/math.vala
+++ b/src/routines/math.vala
@@ -1,7 +1,7 @@
 namespace Vast.Math
 {
     public void
-    add (Array x, Array y, Array z)
+    add (Tensor x, Tensor y, Tensor z)
     {
         var x_iter = x.iterator ();
         var y_iter = y.iterator ();
@@ -12,7 +12,7 @@ namespace Vast.Math
     }
 
     public void
-    negative (Array x, Array z)
+    negative (Tensor x, Tensor z)
         requires (x.size == z.size)
     {
         var x_iter = x.iterator ();
@@ -23,7 +23,7 @@ namespace Vast.Math
     }
 
     public void
-    multiply (Array x, Array y, Array z)
+    multiply (Tensor x, Tensor y, Tensor z)
     {
         var x_iter = x.iterator ();
         var y_iter = y.iterator ();
@@ -35,7 +35,7 @@ namespace Vast.Math
 
     [Vast (gradient_z_x_function = "math_cos")]
     public void
-    sin (Array x, Array z)
+    sin (Tensor x, Tensor z)
         requires (x.size == z.size)
     {
         var x_iter = x.iterator ();
@@ -56,7 +56,7 @@ namespace Vast.Math
     }
 
     public void
-    cos (Array x, Array z)
+    cos (Tensor x, Tensor z)
         requires (x.size == z.size)
     {
         var x_iter = x.iterator ();
@@ -77,14 +77,14 @@ namespace Vast.Math
     }
 
     public void
-    cos_gradient_z_x (Array x, Array z)
+    cos_gradient_z_x (Tensor x, Tensor z)
     {
         sin (x, z);
         negative (z, z);
     }
 
     public void
-    power (Array x, Array y, Array z)
+    power (Tensor x, Tensor y, Tensor z)
         requires (x.size == y.size)
         requires (x.size == z.size)
     {
@@ -110,7 +110,7 @@ namespace Vast.Math
     }
 
     public void
-    power_gradient_z_x (Array x, Array y, Array z)
+    power_gradient_z_x (Tensor x, Tensor y, Tensor z)
     {
         z.fill_from_value (-1);
         add (y, z, z);      // z = a - z = a - 1
@@ -119,7 +119,7 @@ namespace Vast.Math
     }
 
     public void
-    power_gradient_z_y (Array x, Array y, Array z, Array tmp)
+    power_gradient_z_y (Tensor x, Tensor y, Tensor z, Tensor tmp)
     {
         // x ^ y * log (x)
         power (x, y, z);
@@ -128,7 +128,7 @@ namespace Vast.Math
     }
 
     public void
-    log (Array x, Array z)
+    log (Tensor x, Tensor z)
     {
         var x_iter = x.iterator ();
         var z_iter = z.iterator ();

--- a/src/string-formatter.vala
+++ b/src/string-formatter.vala
@@ -1,8 +1,8 @@
 public class Vast.StringFormatter : Vast.Formatter
 {
-    public StringFormatter (Array array)
+    public StringFormatter (Tensor tensor)
     {
-        Object (array: array);
+        Object (tensor: tensor);
     }
 
     private inline void
@@ -10,37 +10,37 @@ public class Vast.StringFormatter : Vast.Formatter
     {
         // scalar style
         @out.put_byte ('\n', cancellable);
-        if (index.length == array.dimension) {
+        if (index.length == tensor.dimension) {
             @out.put_byte ('[');
-            @out.put_string (array.get_value (index).strdup_contents (), cancellable);
+            @out.put_string (tensor.get_value (index).strdup_contents (), cancellable);
             @out.put_byte (']', cancellable);
         }
 
         // vector style
-        else if (index.length == array.dimension - 1) {
+        else if (index.length == tensor.dimension - 1) {
             @out.put_byte ('[');
-            for (var i = 0; i < array.shape[index.length]; i++) {
+            for (var i = 0; i < tensor.shape[index.length]; i++) {
                 if (i > 0)
                     @out.put_byte (' ');
                 // index and print the scalar
                 ssize_t[] subindex = index;
                 subindex += i;
-                @out.put_string (array.get_value (subindex).strdup_contents (), cancellable);
-                if (i < array.shape[index.length] - 1)
+                @out.put_string (tensor.get_value (subindex).strdup_contents (), cancellable);
+                if (i < tensor.shape[index.length] - 1)
                     @out.put_byte ('\n', cancellable);
             }
             @out.put_byte (']', cancellable);
         }
 
         // matrix style
-        else if (index.length == array.dimension - 2) {
+        else if (index.length == tensor.dimension - 2) {
             @out.put_byte ('[');
             // last dim is printed vertically
-            for (var j = 0; j < array.shape[index.length + 1]; j++) {
+            for (var j = 0; j < tensor.shape[index.length + 1]; j++) {
                 if (j > 0) {
                     @out.put_byte (' ', cancellable);
                 }
-                for (var i = 0; i < array.shape[index.length]; i++) {
+                for (var i = 0; i < tensor.shape[index.length]; i++) {
                     if (i > 0) {
                         @out.put_byte (' ', cancellable);
                     }
@@ -50,15 +50,15 @@ public class Vast.StringFormatter : Vast.Formatter
                     ssize_t[] subindex = index;
                     subindex += i;
                     subindex += j;
-                    @out.put_string (array.get_value (subindex).strdup_contents (), cancellable);
+                    @out.put_string (tensor.get_value (subindex).strdup_contents (), cancellable);
 
-                    if (j == array.shape[index.length + 1] - 1) {
+                    if (j == tensor.shape[index.length + 1] - 1) {
                         @out.put_byte (']', cancellable);
                     } else {
                         @out.put_byte (',', cancellable);
                     }
                 }
-                if (j < array.shape[index.length + 1] - 1) {
+                if (j < tensor.shape[index.length + 1] - 1) {
                     @out.put_byte ('\n', cancellable);
                 }
             }
@@ -68,7 +68,7 @@ public class Vast.StringFormatter : Vast.Formatter
         // embedded matrix style (humans can't see beyond!)
         else {
             @out.put_byte ('[');
-            for (var i = 0; i < array.shape[index.length]; i++) {
+            for (var i = 0; i < tensor.shape[index.length]; i++) {
                 ssize_t[] subindex = index;
                 subindex += i;
                 _append_from_index (@out, subindex, cancellable);

--- a/src/tensor.c
+++ b/src/tensor.c
@@ -2,13 +2,13 @@
 #include <glib-object.h>
 
 GBytes*
-_vast_array_bytes_new_zeroed (gsize len)
+_vast_tensor_bytes_new_zeroed (gsize len)
 {
     return g_bytes_new_take (g_malloc0 (len), len);
 }
 
 void*
-_vast_array_value_get_data (GValue *val)
+_vast_tensor_value_get_data (GValue *val)
 {
     return &val->data[0];
 }

--- a/tests/gi-test.py
+++ b/tests/gi-test.py
@@ -3,19 +3,19 @@
 from gi.repository import Vast
 import unittest
 
-class ArrayTestCase(unittest.TestCase):
+class TensorTestCase(unittest.TestCase):
     def test_gobject_construction(self):
-        a = Vast.Array(scalar_type=float, scalar_size=8)
+        a = Vast.Tensor(scalar_type=float, scalar_size=8)
         self.assertEqual(8, a.get_scalar_size())
         self.assertEqual(0, a.get_dimension())
         self.assertEqual(0, a.get_origin())
         self.assertIsNotNone(a.get_data())
 
     def test_builder(self):
-        a = Vast.Array(scalar_type=float, scalar_size=8)
+        a = Vast.Tensor(scalar_type=float, scalar_size=8)
         b = a.build(0).broadcast(0, 5).end()
 
-        builder = Vast.ArrayBuilder(array=a, dimension=0)
+        builder = Vast.TensorBuilder(array=a, dimension=0)
         self.assertEqual(0, builder.get_dimension())
         self.assertIs(a, builder.get_array())
 

--- a/tests/vast-test.vala
+++ b/tests/vast-test.vala
@@ -4,9 +4,9 @@ using Vast;
 int main (string[] args) {
     Test.init (ref args);
 
-    Test.add_func ("/array", () => {
-        var a = new Vast.Array (typeof (double), sizeof (double), {10});
-        var b = new Vast.Array (typeof (double), sizeof (double), {10}, {}, 0, a.data);
+    Test.add_func ("/tensor", () => {
+        var a = new Tensor (typeof (double), sizeof (double), {10});
+        var b = new Tensor (typeof (double), sizeof (double), {10}, {}, 0, a.data);
 
         assert (a.data == b.data);
 
@@ -29,16 +29,16 @@ int main (string[] args) {
         assert (5.0f == a.get_value_as ({5}, typeof (float)));
     });
 
-    Test.add_func ("/array/zeroed", () => {
-        var arr = new Vast.Array (typeof (int), sizeof (int), {10});
+    Test.add_func ("/tensor/zeroed", () => {
+        var arr = new Tensor (typeof (int), sizeof (int), {10});
 
         for (var i = 0; i < 10; i++) {
             assert (0 == arr.get_value ({i}).get_int ());
         }
     });
 
-    Test.add_func ("/array/fill_from_pointer", () => {
-        var arr = new Vast.Array (typeof (int), sizeof (int), {10});
+    Test.add_func ("/tensor/fill_from_pointer", () => {
+        var arr = new Tensor (typeof (int), sizeof (int), {10});
 
         arr.fill_from_value (1);
 
@@ -47,9 +47,9 @@ int main (string[] args) {
         }
     });
 
-    Test.add_func ("/array/fill_from_array", () => {
-        var a = new Vast.Array (typeof (int), sizeof (int), {100});
-        var b = new Vast.Array.zeroed (typeof (int), sizeof (int), {100});
+    Test.add_func ("/tensor/fill_from_tensor", () => {
+        var a = new Tensor (typeof (int), sizeof (int), {100});
+        var b = new Tensor.zeroed (typeof (int), sizeof (int), {100});
 
         a.fill_from_value (1);
 
@@ -57,15 +57,15 @@ int main (string[] args) {
             assert (1 == a.get_value ({i}).get_int ());
         }
 
-        a.fill_from_array (b);
+        a.fill_from_tensor (b);
 
         for (var i = 0; i < 100; i++) {
             assert (0 == a.get_value ({i}).get_int ());
         }
     });
 
-    Test.add_func ("/array/scalar_like", () => {
-        var a = new Vast.Array (typeof (double), sizeof (double), {});
+    Test.add_func ("/tensor/scalar_like", () => {
+        var a = new Tensor (typeof (double), sizeof (double), {});
 
         assert (1 == a.size);
         assert (null != a.data);
@@ -79,8 +79,8 @@ int main (string[] args) {
         assert (!a_iter.next ());
     });
 
-    Test.add_func ("/array/gobject_construction", () => {
-        var a = Object.new (typeof (Vast.Array)) as Vast.Array;
+    Test.add_func ("/tensor/gobject_construction", () => {
+        var a = Object.new (typeof (Tensor)) as Tensor;
 
         assert (0 == a.dimension);
         assert (typeof (void) == a.scalar_type);
@@ -91,7 +91,7 @@ int main (string[] args) {
         assert ("dtype: void, dsize: %lu, dimension: 0, shape: (), strides: (), size: 1, mem: 1B".printf (sizeof (void)) == a.to_string ());
 
         size_t [] shape = {2, 2, 2, 4};
-        var b = Object.new (typeof (Vast.Array), "dimension", shape.length, "shape", shape) as Vast.Array;
+        var b = Object.new (typeof (Tensor), "dimension", shape.length, "shape", shape) as Tensor;
         assert (typeof (void) == b.scalar_type);
         assert (sizeof (void) == b.scalar_size);
         assert (2 == b.shape[0]);
@@ -106,8 +106,8 @@ int main (string[] args) {
         assert (null != b.data);
     });
 
-    Test.add_func ("/array/iterator", () => {
-        var a = new Vast.Array (typeof (double), sizeof (double), {5, 2});
+    Test.add_func ("/tensor/iterator", () => {
+        var a = new Tensor (typeof (double), sizeof (double), {5, 2});
 
         for (var i = 0; i < 5; i++) {
             for (var j = 0; j < 2; j++) {
@@ -134,11 +134,11 @@ int main (string[] args) {
         assert (0 == iter.get_value ().get_double ());
     });
 
-    Test.add_func ("/array/to_string", () => {
-        var s = new Vast.Array (typeof (double), sizeof (double), {1});
+    Test.add_func ("/tensor/to_string", () => {
+        var s = new Tensor (typeof (double), sizeof (double), {1});
         s.set_from_value ({1}, 1);
 
-        var v = new Vast.Array (typeof (double), sizeof (double), {6});
+        var v = new Tensor (typeof (double), sizeof (double), {6});
         v.set_from_value ({0}, 1);
         v.set_from_value ({1}, 1);
         v.set_from_value ({2}, 1);
@@ -146,21 +146,21 @@ int main (string[] args) {
         v.set_from_value ({4}, 1);
         v.set_from_value ({5}, 1);
 
-        var m = new Vast.Array (typeof (double), sizeof (double), {5, 6});
+        var m = new Tensor (typeof (double), sizeof (double), {5, 6});
         m.set_from_value ({0, 1}, 1);
         m.set_from_value ({0, 2}, 1);
         m.set_from_value ({0, 3}, 1);
         m.set_from_value ({0, 4}, 1);
         m.set_from_value ({0, 5}, 1);
 
-        var a = new Vast.Array (typeof (double), sizeof (double), {4, 5, 6});
+        var a = new Tensor (typeof (double), sizeof (double), {4, 5, 6});
         a.set_from_value ({0, 0, 1}, 1);
         a.set_from_value ({0, 0, 2}, 1);
         a.set_from_value ({0, 0, 3}, 1);
         a.set_from_value ({0, 0, 4}, 1);
         a.set_from_value ({0, 0, 5}, 1);
 
-        var b = new Vast.Array (typeof (double), sizeof (double), {1, 2, 3, 4, 5, 6});
+        var b = new Tensor (typeof (double), sizeof (double), {1, 2, 3, 4, 5, 6});
         assert (6 == b.dimension);
         b.set_from_value ({0, 0, 0, 0, 0, 1}, 1);
         b.set_from_value ({0, 0, 0, 0, 0, 2}, 1);
@@ -168,18 +168,18 @@ int main (string[] args) {
         b.set_from_value ({0, 0, 0, 0, 0, 4}, 1);
         b.set_from_value ({0, 0, 0, 0, 0, 5}, 1);
 
-        var c = new Vast.Array (typeof (double), sizeof (double), {1});
+        var c = new Tensor (typeof (double), sizeof (double), {1});
     });
 
-    Test.add_func ("/array/reshape", () => {
-        var a = new Vast.Array (typeof (char), sizeof (char), {10});
+    Test.add_func ("/tensor/reshape", () => {
+        var a = new Tensor (typeof (char), sizeof (char), {10});
         var b = a.reshape ({5, 2});
         assert (5 == b.shape[0]);
         assert (2 == b.shape[1]);
     });
 
-    Test.add_func ("/array/redim", () => {
-        var a = new Vast.Array (typeof (char), sizeof (char), {10});
+    Test.add_func ("/tensor/redim", () => {
+        var a = new Tensor (typeof (char), sizeof (char), {10});
         var b = a.redim (5);
         assert (10 == b.shape[0]);
         assert (1 == b.shape[1]);
@@ -188,8 +188,8 @@ int main (string[] args) {
         assert (1 == b.shape[4]);
     });
 
-    Test.add_func ("/array/compact", () => {
-        var a = new Vast.Array (typeof (uint8), sizeof (uint8), {200});
+    Test.add_func ("/tensor/compact", () => {
+        var a = new Tensor (typeof (uint8), sizeof (uint8), {200});
 
         assert (sizeof (uint8) * 200 == a.size);
 
@@ -197,8 +197,8 @@ int main (string[] args) {
         assert (10 == a.get_value ({0}).get_uchar ());
     });
 
-    Test.add_func ("/array/string", () => {
-        var a = new Vast.Array (typeof (string), sizeof (char) * 10, {10});
+    Test.add_func ("/tensor/string", () => {
+        var a = new Tensor (typeof (string), sizeof (char) * 10, {10});
 
         a.set_from_value  ({0}, "test");
 
@@ -213,12 +213,12 @@ int main (string[] args) {
         assert ("abcd" == a.get_string ({1}));
     });
 
-    Test.add_func ("/array/large", () => {
-        var a = new Vast.Array (typeof (char), sizeof (char), {100, 100, 100, 100});
+    Test.add_func ("/tensor/large", () => {
+        var a = new Tensor (typeof (char), sizeof (char), {100, 100, 100, 100});
     });
 
-    Test.add_func ("/array/boxed_type", () => {
-        var a = new Vast.Array (typeof (DateTime), 128 /* wild guess... */, {10});
+    Test.add_func ("/tensor/boxed_type", () => {
+        var a = new Tensor (typeof (DateTime), 128 /* wild guess... */, {10});
         var b = new DateTime.now_utc ();
         a.set_from_value ({0}, b);
 
@@ -230,8 +230,8 @@ int main (string[] args) {
         assert (b.to_string () == e.to_string ());
     });
 
-    Test.add_func ("/array/negative_indexing", () => {
-        var a = new Vast.Array (typeof (double), sizeof (double), {10, 20});
+    Test.add_func ("/tensor/negative_indexing", () => {
+        var a = new Tensor (typeof (double), sizeof (double), {10, 20});
 
         for(var i = 0; i < 10; i ++) {
             for (var j = 0; j < 20; j++) {
@@ -254,8 +254,8 @@ int main (string[] args) {
         }
     });
 
-    Test.add_func ("/array/index", () => {
-        var a = new Vast.Array (typeof (int64), sizeof (int64), {30, 30});
+    Test.add_func ("/tensor/index", () => {
+        var a = new Tensor (typeof (int64), sizeof (int64), {30, 30});
 
         for (var i = 0; i < 30; i++) {
             for (var j = 0; j < 30; j++) {
@@ -276,8 +276,8 @@ int main (string[] args) {
         }
     });
 
-    Test.add_func ("/array/view_as", () => {
-        var a = new Vast.Array (typeof (double), sizeof (double), {10, 20});
+    Test.add_func ("/tensor/view_as", () => {
+        var a = new Tensor (typeof (double), sizeof (double), {10, 20});
 
         assert (a.shape[0] * 2 == a.view_as (typeof (float), sizeof (float)).shape[0]);
         assert (a.shape[1] * 2 == a.view_as (typeof (float), sizeof (float)).shape[1]);
@@ -288,8 +288,8 @@ int main (string[] args) {
         assert (a.shape[1] == a.view_as (typeof (double), sizeof (double)).shape[1]);
     });
 
-    Test.add_func ("/array/viewbuilder", () => {
-        var a = new Vast.Array (typeof (double), sizeof (double), {10, 20});
+    Test.add_func ("/tensor/viewbuilder", () => {
+        var a = new Tensor (typeof (double), sizeof (double), {10, 20});
 
         for(var i = 0; i < 10; i ++) {
             for (var j = 0; j < 20; j++) {
@@ -384,8 +384,8 @@ int main (string[] args) {
         assert (h.get_value ({1}).get_double () == 0);
     });
 
-    Test.add_func ("/array/slice", () => {
-        var a = new Vast.Array (typeof (int64), sizeof (int64), {30, 30});
+    Test.add_func ("/tensor/slice", () => {
+        var a = new Tensor (typeof (int64), sizeof (int64), {30, 30});
 
         for (var i = 0; i < 30; i++) {
             for (var j = 0; j < 30; j++) {
@@ -428,19 +428,19 @@ int main (string[] args) {
         assert (10 == a.tail ({-10, -10}).shape[0]);
     });
 
-    Test.add_func ("/array/step", () => {
-        var array = new Vast.Array (typeof (int64), sizeof (int64), {10});
+    Test.add_func ("/tensor/step", () => {
+        var tensor = new Tensor (typeof (int64), sizeof (int64), {10});
 
         for (var i = 0; i < 10; i++) {
-            array.set_from_value ({i}, i);
+            tensor.set_from_value ({i}, i);
         }
 
-        assert (5 == array.step ({2}).shape[0]);
-        assert (10 == array.step ({1}).shape[0]);
-        assert (2 == array.step ({5}).shape[0]);
-        assert (3 == array.step ({3}).shape[0]);
+        assert (5 == tensor.step ({2}).shape[0]);
+        assert (10 == tensor.step ({1}).shape[0]);
+        assert (2 == tensor.step ({5}).shape[0]);
+        assert (3 == tensor.step ({3}).shape[0]);
 
-        var stepped = array.step ({2});
+        var stepped = tensor.step ({2});
 
         assert (0 == stepped.get_value ({0}).get_int64 ());
         assert (2 == stepped.get_value ({1}).get_int64 ());
@@ -448,7 +448,7 @@ int main (string[] args) {
         assert (6 == stepped.get_value ({3}).get_int64 ());
         assert (8 == stepped.get_value ({4}).get_int64 ());
 
-        var b = array.step ({-1});
+        var b = tensor.step ({-1});
         assert (9 == b.get_value ({0}).get_int64 ());
         assert (8 == b.get_value ({1}).get_int64 ());
         assert (7 == b.get_value ({2}).get_int64 ());
@@ -456,8 +456,8 @@ int main (string[] args) {
         assert (0 == b.get_value ({9}).get_int64 ());
     });
 
-    Test.add_func ("/array/flip", () => {
-        var a = new Vast.Array (typeof (int64), sizeof (int64), {10});
+    Test.add_func ("/tensor/flip", () => {
+        var a = new Tensor (typeof (int64), sizeof (int64), {10});
 
         for (var i = 0; i < 10; i++) {
             a.set_from_value ({i}, i);
@@ -470,22 +470,22 @@ int main (string[] args) {
         }
     });
 
-    Test.add_func ("/array/transpose", () => {
-        var array = new Vast.Array (typeof (double), sizeof (double), {2, 2});
+    Test.add_func ("/tensor/transpose", () => {
+        var tensor = new Tensor (typeof (double), sizeof (double), {2, 2});
 
-        array.set_from_value ({0, 0}, 1);
-        array.set_from_value ({0, 1}, 2);
-        array.set_from_value ({1, 0}, 3);
-        array.set_from_value ({1, 1}, 4);
+        tensor.set_from_value ({0, 0}, 1);
+        tensor.set_from_value ({0, 1}, 2);
+        tensor.set_from_value ({1, 0}, 3);
+        tensor.set_from_value ({1, 1}, 4);
 
-        var transposed = array.transpose (); // implicit dim 0 and 1
+        var transposed = tensor.transpose (); // implicit dim 0 and 1
 
         assert (1 == transposed.get_value ({0, 0}).get_double ());
         assert (2 == transposed.get_value ({1, 0}).get_double ());
         assert (3 == transposed.get_value ({0, 1}).get_double ());
         assert (4 == transposed.get_value ({1, 1}).get_double ());
 
-        var identity = array.transpose ({1, 0});
+        var identity = tensor.transpose ({1, 0});
 
         assert (1 == identity.get_value ({0, 0}).get_double ());
         assert (2 == identity.get_value ({1, 0}).get_double ());
@@ -493,15 +493,15 @@ int main (string[] args) {
         assert (4 == identity.get_value ({1, 1}).get_double ());
     });
 
-    Test.add_func ("/array/transpose/negative_indexing", () => {
-        var array = new Vast.Array (typeof (double), sizeof (double), {2, 2});
+    Test.add_func ("/tensor/transpose/negative_indexing", () => {
+        var tensor = new Tensor (typeof (double), sizeof (double), {2, 2});
 
-        array.set_from_value ({0, 0}, 1);
-        array.set_from_value ({0, 1}, 2);
-        array.set_from_value ({1, 0}, 3);
-        array.set_from_value ({1, 1}, 4);
+        tensor.set_from_value ({0, 0}, 1);
+        tensor.set_from_value ({0, 1}, 2);
+        tensor.set_from_value ({1, 0}, 3);
+        tensor.set_from_value ({1, 1}, 4);
 
-        var transposed = array.transpose ({-1, -2}); // two last dims
+        var transposed = tensor.transpose ({-1, -2}); // two last dims
 
         assert (1 == transposed.get_value ({0, 0}).get_double ());
         assert (2 == transposed.get_value ({1, 0}).get_double ());
@@ -509,15 +509,15 @@ int main (string[] args) {
         assert (4 == transposed.get_value ({1, 1}).get_double ());
     });
 
-    Test.add_func ("/array/swap", () => {
-        var array = new Vast.Array (typeof (double), sizeof (double), {2, 2});
+    Test.add_func ("/tensor/swap", () => {
+        var tensor = new Tensor (typeof (double), sizeof (double), {2, 2});
 
-        array.set_from_value ({0, 0}, 1);
-        array.set_from_value ({0, 1}, 2);
-        array.set_from_value ({1, 0}, 3);
-        array.set_from_value ({1, 1}, 4);
+        tensor.set_from_value ({0, 0}, 1);
+        tensor.set_from_value ({0, 1}, 2);
+        tensor.set_from_value ({1, 0}, 3);
+        tensor.set_from_value ({1, 1}, 4);
 
-        var swapped = array.swap (0, 1);
+        var swapped = tensor.swap (0, 1);
 
         assert (1 == swapped.get_value ({0, 0}).get_double ());
         assert (2 == swapped.get_value ({1, 0}).get_double ());
@@ -525,7 +525,7 @@ int main (string[] args) {
         assert (4 == swapped.get_value ({1, 1}).get_double ());
     });
 
-    Test.add_func ("/array/mapped", () => {
+    Test.add_func ("/tensor/mapped", () => {
         FileUtils.set_contents ("test", "a");
         MappedFile mapped_file;
 
@@ -535,7 +535,7 @@ int main (string[] args) {
             assert_not_reached ();
         }
 
-        var a = new Vast.Array (typeof (char), sizeof (char),
+        var a = new Tensor (typeof (char), sizeof (char),
                                       {1},
                                       {},
                                       0,
@@ -548,8 +548,8 @@ int main (string[] args) {
         assert ('b' == mapped_file.get_contents ()[0]);
     });
 
-    Test.add_func ("/array/copy", () => {
-        var a = new Vast.Array (typeof (double), sizeof (double), {10});
+    Test.add_func ("/tensor/copy", () => {
+        var a = new Tensor (typeof (double), sizeof (double), {10});
 
         a.set_from_value ({0}, 1.0);
 
@@ -562,8 +562,8 @@ int main (string[] args) {
         assert (1.0 == a.get_value ({0}).get_double ());
     });
 
-    Test.add_func ("/array/broadcast_to", () => {
-        var a = new Vast.Array (typeof (double), sizeof (double));
+    Test.add_func ("/tensor/broadcast_to", () => {
+        var a = new Tensor (typeof (double), sizeof (double));
         a.fill_from_value (1);
 
         var b = a.broadcast_to ({10});
@@ -585,13 +585,13 @@ int main (string[] args) {
 
         var function = new Vast.Function ((GI.FunctionInfo) sin);
 
-        var a = new Vast.Array (typeof (double),
+        var a = new Tensor (typeof (double),
                                 sizeof (double),
                                 {100});
 
         a.fill_from_value (GLib.Math.PI / 2);
 
-        var b = new Vast.Array (typeof (double),
+        var b = new Tensor (typeof (double),
                                 sizeof (double),
                                 {100});
 
@@ -603,13 +603,13 @@ int main (string[] args) {
     });
 
     Test.add_func ("/vast/routines/math/sin", () => {
-        var a = new Vast.Array (typeof (double),
+        var a = new Tensor (typeof (double),
                                 sizeof (double),
                                 {100});
 
     a.fill_from_value (GLib.Math.PI / 2);
 
-    var b = new Vast.Array (typeof (double),
+    var b = new Tensor (typeof (double),
                             sizeof (double),
                             {100});
 
@@ -635,9 +635,9 @@ Test.add_func ("/vast/gradient", () => {
     assert (dz_dx != null);
     assert (dz_dy != null);
 
-    var x = new Vast.Array (typeof (double), sizeof (double), {100});
-    var y = new Vast.Array (typeof (double), sizeof (double), {100});
-    var z = new Vast.Array (typeof (double), sizeof (double), {100});
+    var x = new Tensor (typeof (double), sizeof (double), {100});
+    var y = new Tensor (typeof (double), sizeof (double), {100});
+    var z = new Tensor (typeof (double), sizeof (double), {100});
 
     x.fill_from_value (5.0);
     y.fill_from_value (10.0);
@@ -648,7 +648,7 @@ Test.add_func ("/vast/gradient", () => {
             assert (19531250.0 == *(double*) z.get_pointer ({i}));
         }
 
-        var tmp = new Vast.Array (typeof (double), sizeof (double), {100});
+        var tmp = new Tensor (typeof (double), sizeof (double), {100});
         dz_dy.invoke (x: x, y: y, z: z, tmp: tmp);
 
         for (var i = 0; i < 100; i++) {


### PR DESCRIPTION
There's a few advantages to use the latter:

 - prevent name clash with 'GLib.Array' ad
 - more appropriate since it's a multi-dimensional structure

It's quite a lot of change so I would be glad to get some feedback.